### PR TITLE
Fixed Index out of bounds error

### DIFF
--- a/Harmony/PrettyGrass.cs
+++ b/Harmony/PrettyGrass.cs
@@ -37,6 +37,11 @@ public class OcbPrettyGrass : IModApi
 
     static public void ApplyGamePrefs()
     {
+        if (GameStats.GetInt(EnumGameStats.GameState) == 0)
+        {
+            return;
+        }
+
         MeshDescription.meshes[MeshDescription.MESH_GRASS].material.shader = Shader;
         int quality = GamePrefs.GetInt(EnumGamePrefs.OptionsGfxTerrainQuality);
         MeshDescription.meshes[MeshDescription.MESH_GRASS].bReceiveShadows = quality > 0;


### PR DESCRIPTION
Fixes the Index out of bounds error that appears when applying video settings from the main menu.

Does this by adding a guarded check to see if the game hasn't started when ApplyGamePrefs is called. 